### PR TITLE
Handle multiple validators with a variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,21 @@ A dashboard for the Helium [miner\_exporter](https://github.com/tedder/miner_exp
 # Installing
 
 Import (or copy/paste) the JSON, or **import by ID** `14319`, which uses the [grafana dashboard registry entry](https://grafana.com/grafana/dashboards/14319).
+
+# Prometheus labels per Validator
+This dashboard uses a $validator variable which assumes Prometheus metrics have a a label called "validator". The values of this label should be the short animal name of each validator. Example:
+```yaml
+...
+  - job_name: 'validator'
+    static_configs:
+            - targets: ['aa.yy.zzz:1234', 'aa.yy.zzz:1235']
+              labels:
+                      validator: 'angry-purple-tiger'
+                      network: 'testnet'
+             - targets: ['bb.yy.zzz:1234', 'bb.yy.zzz:1235']
+              labels:
+                      validator: 'sad-dusty-yak'
+                      network: 'testnet'
+...
+```
+If you prefer to organize your prometheus config with one job per validator, you can also use the `labels` keyword under `static_config` instead of nested under `targets`

--- a/helium_miner_dashboard.json
+++ b/helium_miner_dashboard.json
@@ -1,5 +1,14 @@
 {
-  "__inputs": [],
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
   "__requires": [
     {
       "type": "grafana",
@@ -12,6 +21,12 @@
       "id": "graph",
       "name": "Graph",
       "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
     },
     {
       "type": "panel",
@@ -37,12 +52,12 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1619629215336,
+  "iteration": 1620067993743,
   "links": [],
   "panels": [
     {
       "aliasColors": {},
-      "bars": false,
+      "bars": true,
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
@@ -82,8 +97,7 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "$$hashKey": "object:110",
-          "alias": "/validator_inconsensus/",
+          "alias": "concensus",
           "bars": true,
           "color": "rgb(27, 59, 20)",
           "stack": false,
@@ -97,17 +111,18 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "validator_ledger{subtype!=\"total\"}\n",
+          "expr": "validator_ledger{subtype!=\"total\", validator=\"$validator\"}\n",
+          "instant": false,
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "penalty-{{subtype}}",
           "refId": "A"
         },
         {
           "exemplar": true,
-          "expr": "validator_inconsensus  ",
+          "expr": "validator_inconsensus{validator=\"$validator\"}",
           "hide": false,
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "concensus",
           "refId": "B"
         }
       ],
@@ -131,11 +146,12 @@
       },
       "yaxes": [
         {
+          "decimals": 0,
           "format": "short",
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -144,7 +160,7 @@
           "logBase": 1,
           "max": null,
           "min": null,
-          "show": true
+          "show": false
         }
       ],
       "yaxis": {
@@ -221,7 +237,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "validator_version_info",
+          "expr": "validator_version_info{validator=\"$validator\"}",
           "format": "table",
           "instant": false,
           "interval": "",
@@ -308,9 +324,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "validator_sessions",
+          "expr": "validator_sessions{validator=\"$validator\"}",
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "sessions",
           "refId": "A"
         }
       ],
@@ -342,11 +358,12 @@
           "show": true
         },
         {
+          "decimals": 0,
           "format": "short",
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         }
       ],
@@ -402,9 +419,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "validator_block_age",
+          "expr": "validator_block_age{validator=\"$validator\"}",
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "block age",
           "refId": "A"
         }
       ],
@@ -502,9 +519,6 @@
       "points": false,
       "renderer": "flot",
       "seriesOverrides": [
-        {
-          "$$hashKey": "object:1863"
-        }
       ],
       "spaceLength": 10,
       "stack": false,
@@ -512,9 +526,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "validator_connections",
+          "expr": "validator_connections{validator=\"$validator\"}",
           "interval": "1",
-          "legendFormat": "",
+          "legendFormat": "connections",
           "refId": "A"
         }
       ],
@@ -538,7 +552,7 @@
       },
       "yaxes": [
         {
-          "$$hashKey": "object:1874",
+          "decimals": 0,
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -547,7 +561,6 @@
           "show": true
         },
         {
-          "$$hashKey": "object:1875",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -587,6 +600,33 @@
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_PROMETHEUS}",
+        "definition": "label_values(validator)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "validator",
+        "options": [],
+        "query": {
+          "query": "label_values(validator)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 5,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       }
     ]
   },
@@ -596,7 +636,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "miner stats",
+  "title": "Validator stats",
   "uid": "9QGTpK9Mz",
-  "version": 9
+  "version": 10
 }


### PR DESCRIPTION
Overall, add a `validator` variable which is populated from a label
named `validator` in the prometheus config. This allows easy switching
between validators on the dashboard

Also, several cleanups that are probably optional. They are:
* Changed the title from "miner stats" to "Validator stats". Not sure
  this is actually better.

* Turned on `bars` for penalty panel. I think this makes stacking
  easier to see.

* Added aliases and ledgend overrides for all of the queries to make
  them shorter on the panels.

* Truncated decimal places ("decimals": 0) in many places. I think
  this makes the Y axis easier to understand, especially when switching
  between validators.

* Set a min of 0 on many panels, to keep the y-axis from showing
  negative values in an attempt to vertically center data sometimes.

* Hid the right y-axis (consensus) on the penalty panel. Is really a
  binary value. The bars being present as a sort of overaly is all the
  info we need.

Also, Grafana itself seemed to make some other changes with things
like __inputs, __requires, and hashKey. I have no idea if those are
important, but this seems to import for me.

Finally, I'm running Grafana 7.5.5, but I manually reverted the hunks
that changed 7.5.4 -> 7.5.5 and checked I could re-import it just fine.