### PR TITLE
Automagically set 'server_name' when setting 'validator_name' variable

### DIFF
--- a/helium_miner_dashboard.json
+++ b/helium_miner_dashboard.json
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1620506844193,
+  "iteration": 1620595110901,
   "links": [],
   "panels": [
     {
@@ -462,7 +462,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "irate(node_disk_io_time_seconds_total{instance=\"$server_name\"}[15m]) * 100",
+          "expr": "irate(node_disk_io_time_seconds_total{instance=~\"$server_name:.*\"}[15m]) * 100",
           "interval": "",
           "legendFormat": "{{device}}",
           "refId": "A"
@@ -564,14 +564,14 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(node_disk_io_time_weighted_seconds_total{instance=\"$server_name\",device!~\"^sd[ab]\"}[2m])",
+          "expr": "rate(node_disk_io_time_weighted_seconds_total{instance=~\"$server_name:.*\",device!~\"^sd[ab]\"}[2m])",
           "interval": "",
           "legendFormat": "queue len {{device}}",
           "refId": "A"
         },
         {
           "exemplar": true,
-          "expr": "rate(node_disk_write_time_seconds_total{instance=\"$server_name\",device!~\"^sd[ab]\"}[2m])/rate(node_disk_writes_completed_total{instance=\"$server_name\",device!~\"^sd[ab]\"}[2m])",
+          "expr": "rate(node_disk_write_time_seconds_total{instance=~\"$server_name:.*\",device!~\"^sd[ab]\"}[2m])/rate(node_disk_writes_completed_total{instance=~\"$server_name:.*\",device!~\"^sd[ab]\"}[2m])",
           "hide": false,
           "interval": "",
           "legendFormat": "latency {{device}}",
@@ -676,14 +676,14 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "max(node_hwmon_temp_celsius{instance=\"$server_name\"})",
+          "expr": "max(node_hwmon_temp_celsius{instance=~\"$server_name:.*\"})",
           "interval": "",
           "legendFormat": "cpu temp",
           "refId": "A"
         },
         {
           "exemplar": true,
-          "expr": "max(node_ipmi_speed_rpm{instance=\"$server_name\"})",
+          "expr": "max(node_ipmi_speed_rpm{instance=~\"$server_name:.*\"})",
           "hide": false,
           "interval": "",
           "legendFormat": "max fan",
@@ -783,14 +783,14 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "node_load1{instance=\"$server_name\"}",
+          "expr": "node_load1{instance=~\"$server_name:.*\"}",
           "interval": "",
           "legendFormat": "load1",
           "refId": "A"
         },
         {
           "exemplar": true,
-          "expr": "node_load5{instance=\"$server_name\"}",
+          "expr": "node_load5{instance=~\"$server_name:.*\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "load5",
@@ -798,7 +798,7 @@
         },
         {
           "exemplar": true,
-          "expr": "node_memory_MemFree_bytes{instance=\"$server_name\"}/(1024^3)",
+          "expr": "node_memory_MemFree_bytes{instance=~\"$server_name:.*\"}/(1024^3)",
           "hide": false,
           "interval": "",
           "legendFormat": "free mem",
@@ -901,14 +901,14 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "increase(node_network_transmit_bytes_total{device=\"eth0\",instance=\"$server_name\"}[5m])/(1024^2)",
+          "expr": "increase(node_network_transmit_bytes_total{device=\"eth0\",instance=~\"$server_name:.*\"}[5m])/(1024^2)",
           "interval": "",
           "legendFormat": "TX",
           "refId": "A"
         },
         {
           "exemplar": true,
-          "expr": "increase(node_network_receive_bytes_total{device=\"eth0\",instance=\"$server_name\"}[5m])/(1024^2)",
+          "expr": "increase(node_network_receive_bytes_total{device=\"eth0\",instance=~\"$server_name:.*\"}[5m])/(1024^2)",
           "hide": false,
           "interval": "",
           "legendFormat": "RX",
@@ -916,7 +916,7 @@
         },
         {
           "exemplar": true,
-          "expr": "max(node_cpu_scaling_frequency_hertz{instance=\"$server_name\"})",
+          "expr": "max(node_cpu_scaling_frequency_hertz{instance=~\"$server_name:.*\"})",
           "hide": false,
           "interval": "",
           "legendFormat": "core speed",
@@ -1022,21 +1022,21 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "label_values(instance)",
+        "definition": "label_values(validator_version_info{validator_name=\"$validator\"},instance)",
         "description": null,
         "error": null,
-        "hide": 0,
+        "hide": 2,
         "includeAll": false,
         "label": "",
         "multi": false,
         "name": "server_name",
         "options": [],
         "query": {
-          "query": "label_values(instance)",
+          "query": "label_values(validator_version_info{validator_name=\"$validator\"},instance)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
-        "regex": "",
+        "regex": "/^(?<value>.+):[0-9].+$/",
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",


### PR DESCRIPTION
When setting the validator_name variable, use a regex on the instance
field to automatically figure out the FQDN and set server_name to that
value. Then, we can use this FQDN in all the queries that use `instance=`
by using a little more regex in those (`instance=~`).

This assume the promethues targets uses the same IP or FQDN for both
the miner_exporter and node_exporter, varying only the port number.

Also, I hid the server_name variable because there shouldn't be more
than one value to choose from, but it might nice to have a panel that
displated the value of $server_name (it might be an IP or FQDN), but
this is already shown in the "validator version" panel, so I didn't
add that in this commit