### PR TITLE
Filter out non "angry-purple-tiger" names from the validator list

### DIFF
--- a/helium_miner_dashboard.json
+++ b/helium_miner_dashboard.json
@@ -1009,7 +1009,7 @@
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
-        "regex": "",
+        "regex": "/^\\w+-\\w+-\\w+$/",
         "skipUrlSync": false,
         "sort": 5,
         "tagValuesQuery": "",


### PR DESCRIPTION
If there's an error communicating with the miner_exporter, an error message can be added to the value list for validator variables. As an example, I seen:
"Error: Usage information not found for..."

To fix this, I added a simple regex to filter the values to things that look like "foo-bar-baz". I was intentionally a little permissive,
using \w for the words instead of [a-z]+